### PR TITLE
prop: remove disabled knox

### DIFF
--- a/build/system/etc/prop.default_g960f
+++ b/build/system/etc/prop.default_g960f
@@ -9,7 +9,6 @@ ro.adb.secure=1
 ro.allow.mock.location=0
 ro.debuggable=0
 
-ro.config.knox=v0
 ro.config.tima=0
 ro.security.vaultkeeper.feature=0
 wlan.wfd.hdcp=disable

--- a/build/system/etc/prop.default_g965f
+++ b/build/system/etc/prop.default_g965f
@@ -9,7 +9,6 @@ ro.adb.secure=1
 ro.allow.mock.location=0
 ro.debuggable=0
 
-ro.config.knox=v0
 ro.config.tima=0
 ro.security.vaultkeeper.feature=0
 wlan.wfd.hdcp=disable


### PR DESCRIPTION
no need to disable knox property.

fixes webview copy/paste, split view crash on systemui and other potential software issues